### PR TITLE
feat: add dbdump REST API to cord SDK cli

### DIFF
--- a/opensource/cli/src/commands/application.ts
+++ b/opensource/cli/src/commands/application.ts
@@ -17,6 +17,15 @@ async function listAllApplicationsHandler() {
   prettyPrint(apps);
 }
 
+async function dbDumpHandler() {
+  const dump = await fetchCordManagementApi<ApplicationData[]>(
+    'customer/dbdump',
+    'GET',
+    undefined,
+    'text',
+  );
+  console.log(dump);
+
 async function whichApplicationHandler() {
   const variables = await getEnvVariables().catch(() => {
     /* no op, catch below instead */
@@ -196,6 +205,7 @@ export const projectCommand = {
         (yargs) => yargs,
         listAllApplicationsHandler,
       )
+      .command('dbdump', 'Bump DB', (yargs) => yargs, dbDumpHandler)
       .command(
         'get <id>',
         'Get a project: GET https://api.cord.com/v1/projects/<ID>',

--- a/opensource/cli/src/fetchCordRESTApi.ts
+++ b/opensource/cli/src/fetchCordRESTApi.ts
@@ -50,6 +50,7 @@ export async function fetchCordManagementApi<T>(
   endpoint: string,
   method: 'GET' | 'PUT' | 'POST' | 'DELETE' = 'GET',
   body?: string,
+  type: 'json' | 'text' = 'json',
 ): Promise<T> {
   const env = await getEnvVariables().catch(() => {
     /*no-op. probably just doesn't exist yet*/
@@ -80,7 +81,7 @@ export async function fetchCordManagementApi<T>(
   });
 
   if (response.ok) {
-    return response.json() as T;
+    return type === 'text' ? (await response.text() as T) : (await response.json() as T);
   } else {
     const responseText = await response.text();
     throw new Error(


### PR DESCRIPTION
Adding support to dbDumps to Cord cli.

This is a nice to have feature to help everyone on the data migration process

Usage Examples local build:
```
./dist/index.js project

cord project

Manipulate projects. For more info refer to docs: https://docs.cord.com/rest-apis/projects

Commands:
  cord project ls                     List all projects: GET https://api.cord.com/v1/projects
  cord project dbdump                 Dumps all data from all project
  cord project get <id>               Get a project: GET https://api.cord.com/v1/projects/<ID>
  cord project create                 Create a project: POST https://api.cord.com/v1/projects
  cord project update <id>            Update a project: PUT https://api.cord.com/v1/projects/<ID>
  cord project delete [--force] <id>  Delete a project: DELETE https://api.cord.com/v1/projects/<ID>
  cord project select                 Select a project you would like to use
  cord project which                  See the project you are using

Options:
  --version  Show version number                                                                                                         [boolean]
  --help     Show help                                                                                                                   [boolean]
```

Actual dump
```
./dist/index.js project dbdump > db_dump.sql
```

