### PR TITLE
feat: add JSON log format

### DIFF
--- a/server/src/logging/Logger.ts
+++ b/server/src/logging/Logger.ts
@@ -55,10 +55,13 @@ if (sentryLogging) {
 // Winston logging
 const winstonLogger = winston.createLogger({ defaultMeta });
 
+const format =
+  process.env.LOG_FORMAT === 'json' ? winston.format.json() : flatFormat();
+
 winstonLogger.add(
   new winston.transports.Console({
     level: logLevel,
-    format: winston.format.combine(winston.format.timestamp(), flatFormat()),
+    format: winston.format.combine(winston.format.timestamp(), format),
     handleExceptions: true,
   }),
 );


### PR DESCRIPTION
Proposing a simple change to add JSON log format.

Can be configured by a new env var `LOG_FORMAT`, backward compatible if not declared

use:
LOG_FORMAT = 'json'
To enable JSON logs
