### PR TITLE
feat: add Redis TLS and DB options

### DIFF
--- a/server/src/config/Env.ts
+++ b/server/src/config/Env.ts
@@ -37,8 +37,15 @@ export default magicEnv(process.env, {
   // Redis connection configuration
   REDIS_PORT: required,
   REDIS_HOST: required,
+  REDIS_USE_TLS: optional,
+  REDIS_REJECT_UNAUTHORIZED: optional,
+  REDIS_DB: optional,
+
   PREDIS_PORT: required,
   PREDIS_HOST: required,
+  PREDIS_USE_TLS: optional,
+  PREDIS_REJECT_UNAUTHORIZED: optional,
+  PREDIS_DB: optional,
 
   // URLs pointing to our own endpoints
   TOP_SERVER_HOST: required,

--- a/server/src/redis/index.ts
+++ b/server/src/redis/index.ts
@@ -81,12 +81,26 @@ export function initRedis() {
   redlock = new Redlock([redis]);
 }
 
+function getTlsOptions(useTls: string | undefined, rejectUnauthorized: string | undefined) {
+  return useTls === 'true'
+    ? {
+        tls: {
+          rejectUnauthorized: rejectUnauthorized === 'true',
+        },
+      }
+    : {};
+}
+
 export function createRedisClient(): RedisClient {
-  return new Redis.default(Number(env.REDIS_PORT), env.REDIS_HOST);
+  const tlsOptions = getTlsOptions(env.REDIS_USE_TLS, env.REDIS_REJECT_UNAUTHORIZED);
+  const db = env.REDIS_DB ? Number(env.REDIS_DB) : 0;
+  return new Redis.default(Number(env.REDIS_PORT), env.REDIS_HOST, { ...tlsOptions, db } );
 }
 
 export function createPredisClient(): RedisClient {
-  return new Redis.default(Number(env.PREDIS_PORT), env.PREDIS_HOST);
+  const tlsOptions = getTlsOptions(env.PREDIS_USE_TLS, env.PREDIS_REJECT_UNAUTHORIZED);
+  const db = env.PREDIS_DB ? Number(env.PREDIS_DB) : 0;
+  return new Redis.default(Number(env.PREDIS_PORT), env.PREDIS_HOST, { ...tlsOptions, db } );
 }
 
 // This is a helper function to check for errors after a Redis MULTI


### PR DESCRIPTION
Adds optional TLS and DB configuration to redis

example:
`REDIS_USE_TLS` = 'true' # defaults to false
`REDIS_REJECT_UNAUTHORIZED` = 'true' # defaults to false, verifies CA cert or not
`REDIS_DB` = '1' # defaults to 0

for presence redis basically the same:

`PREDIS_USE_TLS` 
`PREDIS_REJECT_UNAUTHORIZED`
`PREDIS_DB`

