### PR TITLE
Composer: Correctly pass className to DragAndDropDiv

### DIFF
--- a/external/src/components/ui3/DragAndDropDiv.tsx
+++ b/external/src/components/ui3/DragAndDropDiv.tsx
@@ -53,7 +53,11 @@ export function DragAndDropDiv({
 
   if (disabled) {
     return (
-      <div ref={forwardRef} {...otherProps}>
+      <div
+        ref={forwardRef}
+        className={cx(classes.dndContainer, className)}
+        {...otherProps}
+      >
         {children}
       </div>
     );


### PR DESCRIPTION
Summary:

When file attachments are disabled, and we render a dummy div instead of the DragAndDrop one, we were not passing `className` down correctly, which resulted in the component looking broken, as CSS wasn't being applied correctly.

<img width="387" alt="image" src="https://github.com/user-attachments/assets/9febf880-5ca4-4e17-b891-ba137a9672d8">
