### PR TITLE
feat(workers): Optional Admin and Console Server Workers

### DIFF
--- a/scripts/generate-dotenv.cjs
+++ b/scripts/generate-dotenv.cjs
@@ -206,6 +206,8 @@ function buildProdEnv(commitHash) {
     DEMO_APPS_SHARED_SECRET: secrets.DEMO_APPS_SHARED_SECRET.key,
     LOOPS_SO_API_KEY: secrets.LOOPS_SO_API_KEY.api_key,
     PYROSCOPE_ENDPOINT: 'http://monitoring.int.cord.com:4040',
+    IGNORE_ADMIN_SERVER_WORKER: false,
+    IGNORE_CONSOLE_SERVER_WORKER: false,
   };
 }
 

--- a/server/src/config/Env.ts
+++ b/server/src/config/Env.ts
@@ -233,4 +233,10 @@ export default magicEnv(process.env, {
 
   // loops.so for sending newletters
   LOOPS_SO_API_KEY: required,
+
+  // Make Admin Server Optional
+  IGNORE_ADMIN_SERVER_WORKER: optional,
+
+  // Make Admin Server Optional
+  IGNORE_CONSOLE_SERVER_WORKER: optional,
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -180,7 +180,7 @@ async function main() {
   // -------------------------------------------------------------------------
   // ADMIN
 
-  if (isSingleProcessOrMaster || workerType === 'admin') {
+  if (!env.IGNORE_ADMIN_SERVER_WORKER && (isSingleProcessOrMaster || workerType === 'admin')) {
     // Either we are not in cluster mode, or this process is the master or an
     // 'admin' worker. (If this is a worker process of a different type, we skip
     // this section.)
@@ -210,7 +210,7 @@ async function main() {
   // -------------------------------------------------------------------------
   // CONSOLE
 
-  if (isSingleProcessOrMaster || workerType === 'console') {
+  if (!env.IGNORE_CONSOLE_SERVER_WORKER && (isSingleProcessOrMaster || workerType === 'console')) {
     // Either we are not in cluster mode, or this process is the master or an
     // 'console' worker. (If this is a worker process of a different type, we skip
     // this section.)


### PR DESCRIPTION
In order to facilitate the work for https://github.com/getcord/cord/issues/23 we are adding two more env variables to the config so we can opt in/out from the Admin and Console server workers due to their optional nature. By default you would be running all workers as currently does the app.

Ideally we could control which server workers to run when serving your self hosted solution via a Feature Flag, but currently the Feature Flags are managed by LaunchDarkly which would be an optional service after we address https://github.com/getcord/cord/issues/2.

