### PR TITLE
Skip optional workers based on port number

### DIFF
--- a/scripts/generate-dotenv.cjs
+++ b/scripts/generate-dotenv.cjs
@@ -206,8 +206,6 @@ function buildProdEnv(commitHash) {
     DEMO_APPS_SHARED_SECRET: secrets.DEMO_APPS_SHARED_SECRET.key,
     LOOPS_SO_API_KEY: secrets.LOOPS_SO_API_KEY.api_key,
     PYROSCOPE_ENDPOINT: 'http://monitoring.int.cord.com:4040',
-    IGNORE_ADMIN_SERVER_WORKER: false,
-    IGNORE_CONSOLE_SERVER_WORKER: false,
   };
 }
 

--- a/server/src/config/Env.ts
+++ b/server/src/config/Env.ts
@@ -233,10 +233,4 @@ export default magicEnv(process.env, {
 
   // loops.so for sending newletters
   LOOPS_SO_API_KEY: required,
-
-  // Make Admin Server Optional
-  IGNORE_ADMIN_SERVER_WORKER: optional,
-
-  // Make Admin Server Optional
-  IGNORE_CONSOLE_SERVER_WORKER: optional,
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -180,7 +180,10 @@ async function main() {
   // -------------------------------------------------------------------------
   // ADMIN
 
-  if (!env.IGNORE_ADMIN_SERVER_WORKER && (isSingleProcessOrMaster || workerType === 'admin')) {
+  if (
+    env.ADMIN_SERVER_PORT &&
+    (isSingleProcessOrMaster || workerType === 'admin')
+  ) {
     // Either we are not in cluster mode, or this process is the master or an
     // 'admin' worker. (If this is a worker process of a different type, we skip
     // this section.)
@@ -210,7 +213,10 @@ async function main() {
   // -------------------------------------------------------------------------
   // CONSOLE
 
-  if (!env.IGNORE_CONSOLE_SERVER_WORKER && (isSingleProcessOrMaster || workerType === 'console')) {
+  if (
+    env.CONSOLE_SERVER_PORT &&
+    (isSingleProcessOrMaster || workerType === 'console')
+  ) {
     // Either we are not in cluster mode, or this process is the master or an
     // 'console' worker. (If this is a worker process of a different type, we skip
     // this section.)


### PR DESCRIPTION
The optional workers in #24 doesn't quite work right: because env variables are always strings, `generate-dotenv.cjs` will set these two new env vars to the string `'false'` -- which is truthy. So the console and admin workers will always be deactivated unless we set the value to the string `''` or similar, which is confusing for these boolean-sounding settings.

Instead, we can just check if the port number is set, and skip if not, which is nice that we don't need a new env var -- you can just set the port number to the empty string to deactivate.  This does have a similar issue, in that if you set the port to `'0'`, it will still try to activate the optional worker -- but `parseListenPort` will immediately yell that `0` is an invalid port so at least you know immediately.